### PR TITLE
fix: Popover 반응형에서 짤리는 현상 수정

### DIFF
--- a/src/pages/TopicHistoryPage.tsx
+++ b/src/pages/TopicHistoryPage.tsx
@@ -36,7 +36,7 @@ interface GuidePopoverProps {
     message: string;
 }
 
-function GuidePopover({button, message}: GuidePopoverProps) {
+function GuidePopover({ button, message }: GuidePopoverProps) {
     const [isGuideShown, setIsGuideShown] = useState(localStorage.getItem('isGuideShown') === 'true');
     const popoverOpen = !isGuideShown;
 
@@ -46,7 +46,7 @@ function GuidePopover({button, message}: GuidePopoverProps) {
     };
 
     return (
-        <div className="flex justify-end w-full">
+        <div className="relative w-full">
             {popoverOpen && (
                 <div
                     className="fixed inset-0 bg-black bg-opacity-60 z-40"
@@ -54,17 +54,22 @@ function GuidePopover({button, message}: GuidePopoverProps) {
                 />
             )}
 
-            <Popover
-                open={popoverOpen}
-                onOpenChange={() => handleClose()}
-            >
+            <Popover open={popoverOpen} onOpenChange={handleClose}>
                 <PopoverTrigger asChild>
                     {button}
                 </PopoverTrigger>
+
                 <PopoverContent
-                    side="right"
+                    className={`
+                        z-50 bg-white text-black rounded-lg shadow-lg p-4
+                        w-[60vw] max-w-xs
+                        sm:w-60 sm:max-w-xs
+                        absolute sm:relative left-1/2 transform -translate-x-1/2 mt-2
+                        translate-x-1
+                    `}
+                    side="bottom"
                     align="center"
-                    className="bg-white text-black rounded-lg shadow-lg p-4 w-80"
+                    sideOffset={8}
                 >
                     {message}
                 </PopoverContent>
@@ -72,6 +77,7 @@ function GuidePopover({button, message}: GuidePopoverProps) {
         </div>
     );
 }
+
 
 const TopicHistoryItem = ({title, datetime, description, thumbnail, onClick, index, isLast}: TopicHistoryItemProps) => (
     <div className="relative group animate-in slide-in-from-left-5 fade-in duration-700"


### PR DESCRIPTION
다음과 같은 변경사항을 포함합니다.

- GuidePopover 컴포넌트 CSS 수정

- 수정전 
<img width="300" alt="스크린샷 2025-06-30 오후 9 45 37" src="https://github.com/user-attachments/assets/d9602ac6-d145-4ea8-9496-0c4e57dfa804" />

- 수정후
<img width="300" alt="image" src="https://github.com/user-attachments/assets/08af6bed-610e-496a-ab65-73d46f5c3a40" />